### PR TITLE
change task priority from integer into string data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Database diagram https://dbdiagram.io/d/5f9b12403a78976d7b79bc81
 
 ### Development
 	See Gemfile 
+
+When any database changes are made (E.g. migrations, schema.db updates etc.) local Database must be destroyed and rebuilt via: 
+`rails db:reset` which is an alias for `rails db:drop db:create db:migrate`

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  enum priority: { high: 1, medium: 2, low: 3 }
-  # ensues a Task record cannot be created if its missing description and priority
+  enum priority: { high: "high", medium: "medium", low: "low" }
+  # ensures a Task record cannot be created if its missing description and priority
   validates_presence_of :description, :priority
 end

--- a/db/migrate/20210114010220_change_tasks_priority_type.rb
+++ b/db/migrate/20210114010220_change_tasks_priority_type.rb
@@ -1,0 +1,7 @@
+class ChangeTasksPriorityType < ActiveRecord::Migration[6.0]
+  def change
+    change_table :tasks do |t|
+      t.change(:priority, :string)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_195159) do
+ActiveRecord::Schema.define(version: 2021_01_14_010220) do
 
   create_table "tasks", force: :cascade do |t|
     t.string "description"
-    t.integer "priority"
+    t.string "priority"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Lailson says we shouldn't have Task priority data be an integer it should instead be a string to reduce issues and odd bugs in the future. E.g. `priority: 1` was changed to `priority: "low"`

Once this is merged to master, all devs need to rebuid their local db via: rails db:reset