### PR TITLE
Add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When any database changes are made (E.g. migrations, schema.db updates etc.) loc
 `rails db:reset` which is an alias for `rails db:drop db:create db:migrate`
 
 ### Tests
-minitest model unit tests
+#### minitest model unit tests
 
 run a test file:
 ```
@@ -27,3 +27,6 @@ TBD
 run tests in a directory
 TBD
 
+#### controller tests
+`bin/rails test test/controllers/homepage_controller_test.rb`
+`bin/rails test test/controllers/thoughts_controller_test.rb`

--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ Database diagram https://dbdiagram.io/d/5f9b12403a78976d7b79bc81
 
 When any database changes are made (E.g. migrations, schema.db updates etc.) local Database must be destroyed and rebuilt via: 
 `rails db:reset` which is an alias for `rails db:drop db:create db:migrate`
+
+### Tests
+minitest model unit tests
+
+run a test file:
+```
+bin/rails test test/models/thought_test.rb
+bin/rails test test/models/task_test.rb
+```
+
+run all model tests
+TBD
+
+run tests in a directory
+TBD
+

--- a/test/controllers/homepage_controller_test.rb
+++ b/test/controllers/homepage_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class HomepageControllerTest < ActionDispatch::IntegrationTest
-  test "should get greeting" do
-    get homepage_greeting_url
+  test "homepage should load" do
+    get root_url
     assert_response :success
   end
 

--- a/test/controllers/thoughts_controller_test.rb
+++ b/test/controllers/thoughts_controller_test.rb
@@ -20,7 +20,7 @@ class ThoughtsControllerTest < ActionDispatch::IntegrationTest
       post thoughts_url, params: { thought: { description: @thought.description } }
     end
 
-    assert_redirected_to thought_url(Thought.last)
+    assert_redirected_to root_url
   end
 
   test "should show thought" do
@@ -43,6 +43,6 @@ class ThoughtsControllerTest < ActionDispatch::IntegrationTest
       delete thought_url(@thought)
     end
 
-    assert_redirected_to thoughts_url
+    assert_redirected_to root_url
   end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,7 +1,32 @@
 require 'test_helper'
+require 'minitest/autorun'
 
 class TaskTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+end
+
+class TaskModelTest < Minitest::Test
+  def test_task_created_when_required_data_exists
+    record_created = Task.new(description: 'blahfoobar', priority: 'low').save
+    assert(record_created == true)
+    fetch_created_record = Task.where(description: 'blahfoobar', priority: 'low').exists?
+    assert(fetch_created_record == true)
+  end
+
+  def test_tasks_not_created_when_missing_priorty
+    record_created = Task.new(description: 'blah').save
+    assert(record_created == false)
+  end
+
+  def test_tasks_not_created_when_missing_description
+    record_created = Task.new(priority: 'low').save
+    assert(record_created == false)
+  end
+
+  def test_tasks_not_created_when_missing_required_data
+    record_created = Task.new().save
+    assert(record_created == false)
+  end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -8,6 +8,7 @@ class TaskTest < ActiveSupport::TestCase
 end
 
 class TaskModelTest < Minitest::Test
+  # Testing Task.new and not Task.create because Task.new is used the TasksController.
   def test_task_created_when_required_data_exists
     record_created = Task.new(description: 'blahfoobar', priority: 'low').save
     assert(record_created == true)

--- a/test/models/thought_test.rb
+++ b/test/models/thought_test.rb
@@ -1,7 +1,25 @@
 require 'test_helper'
+require 'minitest/autorun'
 
 class ThoughtTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+end
+
+class ThoughtModelTest < Minitest::Test
+  def test_thought_created_when_required_data_exists
+    record_created = Thought.new(description: 'blah').save
+    assert(record_created == true)
+    fetch_created_record = Thought.where(description: 'blah').exists?
+    assert(fetch_created_record == true)
+  end
+
+  # To simulate a breaking app change is caught by this test:
+  # 1. go to app/models/thought.rb
+  # 2. comment out validates_presence_of :description
+  def test_thought_not_created_when_missing_required_data
+    record_created = Thought.new().save
+    assert(record_created == false)
+  end
 end


### PR DESCRIPTION
- added [minitest](https://github.com/seattlerb/minitest) unit tests for the task and thought models
NOTE: we'll use minitest for now and either add or swap to Rspec tests if needed
- fixed auto-generated controller tests, because redirects were changed
- updated readme with how to run tests

# reference docs we used
[Good overview](https://guides.rubyonrails.org/v3.2/testing.html) of the kinds of unit tests. (latest rails tests [doc](https://www.simform.com/unit-testing-vs-functional-testing/))
https://www.simform.com/unit-testing-vs-functional-testing/
[Launch School unit tests doc](https://launchschool.com/blog/assert-yourself-an-introduction-to-minitest)

[mini tests vs rspec](https://stackoverflow.com/questions/12470601/minitest-and-rspec)
[exists? method](https://apidock.com/rails/ActiveRecord/Base/exists%3f/class)
[rails Model_name.new vs  Model_name.create](https://stackoverflow.com/questions/2472393/rails-new-vs-create)
[unit test vs integration test](https://medium.com/android-testing-daily/unit-test-vs-integration-tes-fba13b92fbf6)