### PR TITLE
add codecov to get test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 # Ignore ide file
 .idea/
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'simplecov', require: false, group: :test
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    docile (1.3.5)
     erubi (1.9.0)
     ffi (1.13.1)
     globalid (0.4.2)
@@ -156,6 +157,12 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -209,6 +216,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.1)
   sass-rails (>= 6)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,8 @@
 class Task < ApplicationRecord
   enum priority: { high: "high", medium: "medium", low: "low" }
   # ensures a Task record cannot be created if its missing description and priority
-  validates_presence_of :description, :priority
+  # validates_presence_of :description, :priority
+  validates :description, presence: true
+  validates :priority, presence: true
 end
+

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -1,5 +1,4 @@
 class UserCategory < ApplicationRecord
-  belongs_to :user, :dependent => :destroy
+  # belongs_to :user, :dependent => :destroy
+  belongs_to :user, dependent: :destroy
 end
-
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'


### PR DESCRIPTION
added https://github.com/simplecov-ruby/simplecov and generated a report.

1. ran tests via: `bin/rails test`
2. opened report file in a browser `get-things-done-app/coverage/index.html`
![Screen Shot 2021-01-23 at 12 37 40 PM](https://user-images.githubusercontent.com/16140873/105613507-d02c7d00-5d77-11eb-806f-58db8972ce56.png)

TODO

- [ ] ask someone how to interpret the report
- [ ] why were some test files displaying in the report and why are some test lines red?