### PR TITLE
add fixture data and refactor unit tests

### DIFF
--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  description: MyString
-  priority: 
+  description: Adopt a cat
+  priority: high
 
 two:
-  description: MyString
-  priority: 
+  description: Buy Boots
+  priority: low

--- a/test/fixtures/thoughts.yml
+++ b/test/fixtures/thoughts.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  description: MyString
+  description: My room is lonely
 
 two:
-  description: MyString
+  description: My shoes are old

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -2,32 +2,23 @@ require 'test_helper'
 require 'minitest/autorun'
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end
-
-class TaskModelTest < Minitest::Test
-  # Testing Task.new and not Task.create because Task.new is used the TasksController.
-  def test_task_created_when_required_data_exists
-    record_created = Task.new(description: 'blahfoobar', priority: 'low').save
-    assert(record_created == true)
-    fetch_created_record = Task.where(description: 'blahfoobar', priority: 'low').exists?
-    assert(fetch_created_record == true)
+  test "test_task_created_when_required_data_exists" do
+    assert Task.create(description: 'blahfoobar', priority: 'low')
   end
 
-  def test_tasks_not_created_when_missing_priorty
-    record_created = Task.new(description: 'blah').save
-    assert(record_created == false)
+  test "test_tasks_not_created_when_missing_priority" do
+    task = Task.new(priority: nil)
+    refute task.save
+
+    assert task.errors.include?(:priority)
+    assert task.errors.details[:priority].include?(error: :blank)
   end
 
-  def test_tasks_not_created_when_missing_description
-    record_created = Task.new(priority: 'low').save
-    assert(record_created == false)
-  end
+  test "test_tasks_not_created_when_missing_description" do
+    task = Task.new(description: nil)
+    refute task.save
 
-  def test_tasks_not_created_when_missing_required_data
-    record_created = Task.new().save
-    assert(record_created == false)
+    assert task.errors.include?(:description)
+    assert task.errors.details[:description].include?(error: :blank)
   end
 end

--- a/test/models/thought_test.rb
+++ b/test/models/thought_test.rb
@@ -2,24 +2,18 @@ require 'test_helper'
 require 'minitest/autorun'
 
 class ThoughtTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end
-
-class ThoughtModelTest < Minitest::Test
-  def test_thought_created_when_required_data_exists
-    record_created = Thought.new(description: 'blah').save
-    assert(record_created == true)
-    fetch_created_record = Thought.where(description: 'blah').exists?
-    assert(fetch_created_record == true)
+  test "thought record is created when required data exists" do
+    assert Thought.create(description: 'blahfoobar')
   end
 
   # To simulate a breaking app change is caught by this test:
   # 1. go to app/models/thought.rb
   # 2. comment out validates_presence_of :description
-  def test_thought_not_created_when_missing_required_data
-    record_created = Thought.new().save
-    assert(record_created == false)
+  test "thought record fails to create when missing required data" do
+    thought = Thought.new(description: nil)
+    refute thought.save
+
+    assert thought.errors.include?(:description)
+    assert thought.errors.details[:description].include?(error: :blank)
   end
 end


### PR DESCRIPTION
## What
created fixtures data for future tests and refactored minitest unit tests so fixtures are created when tests run. 

## Why
when we 1st created unit tests in https://github.com/KellyAH/get-things-done-app/pull/14 we used the minitest readme which assumed we weren't using Rails. Rails already has minitest auto-installed and all the integration setup with it. So we should've written our tests in the existing `class TaskTest < ActiveSupport::TestCase` which was created when we auto generated models.

# Tests
confirmed tests pass on my local by running  `bin/rails test`